### PR TITLE
Fix langchain import warning

### DIFF
--- a/prediction_market_agent/tools/web_scrape.py
+++ b/prediction_market_agent/tools/web_scrape.py
@@ -3,7 +3,7 @@ import requests
 
 from langchain.chains.summarize import load_summarize_chain
 from langchain_openai import ChatOpenAI
-from langchain import PromptTemplate
+from langchain.prompts import PromptTemplate
 from langchain.text_splitter import RecursiveCharacterTextSplitter
 
 


### PR DESCRIPTION
No more of this:

```
/Users/evan/dev/prediction-market-agent/.venv/lib/python3.9/site-packages/langchain/__init__.py:29: UserWarning: Importing PromptTemplate from langchain root module is no longer supported. Please use langchain.prompts.PromptTemplate instead.
  warnings.warn(
```